### PR TITLE
Barcode Search, Accessions Import, and EADID search fix

### DIFF
--- a/Config.xml
+++ b/Config.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ArchivesSpace Containers</Name>
   <Author>Cédric Viaccoz</Author>
-  <Version>1.0</Version>
+  <Version>1.1</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>Retrieve top containers linked to the call number, title or ead_id of a resource</Description>

--- a/Config.xml
+++ b/Config.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.1" encoding="utf-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ArchivesSpace Containers</Name>
   <Author>Cédric Viaccoz</Author>

--- a/Config.xml
+++ b/Config.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>ArchivesSpace Containers</Name>
   <Author>Cédric Viaccoz</Author>

--- a/EventHandlers.lua
+++ b/EventHandlers.lua
@@ -18,6 +18,12 @@ function EADIDSubmitCheck(sender, args)
 	end
 end
 
+function BarcodeSubmitCheck(sender, args)
+	if tostring(args.KeyCode) == "Return: 13" then
+		performSearch(barcodeTerm, 'barcode')
+	end
+end
+
 
 
 function performSearch(field, fieldName)
@@ -28,15 +34,23 @@ function performSearch(field, fieldName)
 		if field == eadidTerm then
 			collectionTitle.Value = ''
 			searchTerm.Value = ''
+			barcodeTerm.Value = ''
 			res = getTopContainersByEADID(field.Value)
 		elseif field == collectionTitle then
 			eadidTerm.Value = ''
 			searchTerm.Value = ''
+			barcodeTerm.Value = ''
 			res = getTopContainersByTitle(field.Value)
 		elseif field == searchTerm then
 			collectionTitle.Value = ''
 			eadidTerm.Value = ''
+			barcodeTerm.Value = ''
 			res = getTopContainersByCallNumber(field.Value)
+		elseif field == barcodeTerm then
+			collectionTitle.Value = ''
+			searchTerm.Value = ''
+			eadidTerm.Value = ''
+			res = getTopContainersByBarcode(field.Value)
 		end
 
 		GetBoxes(convertResultsIntoDataTable(res), fieldName)

--- a/Grids.lua
+++ b/Grids.lua
@@ -155,4 +155,16 @@ function fillItemTable(gridControl)
 	gridColumn.VisibleIndex = 9 
 	gridColumn.OptionsColumn.ReadOnly = true 
 
+
+	local gridColumn 
+	gridColumn = gridView.Columns:Add() 
+	gridColumn.Caption = "HiddenDocPath" 
+	gridColumn.FieldName = "doc_path" 
+	gridColumn.Name = "gcDoc_path" 
+	gridColumn.Width = 0
+	gridColumn.Visible = true 
+	gridColumn.VisibleIndex = -1 -- hids this grid. 
+	gridColumn.OptionsColumn.ReadOnly = true 
+
+
 end

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -22,8 +22,15 @@ function findObjectTypeInCollection(obj, typestr)
 	if idx == ctrlCount then
 		return nil;
 	end
-
 end
+
+-- cannot use '#' if the table is not numerically indexed in sequence. 
+function tableLength(T)
+  local count = 0
+  for _ in pairs(T) do count = count + 1 end
+  return count
+end
+
 
 function getLength(obj)
 	local idx = 0;

--- a/Main.lua
+++ b/Main.lua
@@ -11,7 +11,6 @@ settings["AddonName"] = globalInterfaceMngr.environment.Info.Name
 settings["AddonVersion"] = globalInterfaceMngr.environment.Info.Version 
 settings["LogLabel"] = settings.AddonName .. " v" .. settings.AddonVersion 
 
-
 LogDebug("Launching ASpace Basic Plugin") 
 LogDebug("Loading Assemblies") 
 LogDebug("Loading System Data Assembly") 
@@ -39,8 +38,6 @@ require "Atlas-Addons-Lua-ParseJson.JsonParser"
 
 local form = nil 
 interfaceMngr = nil 
-
-
 
 function Init()
 
@@ -171,21 +168,10 @@ function containersSearch()
 	end
 end
 
-
 function getFullResourceById(repoID, resourceId)
 	local searchResourceReq = 'repositories/' .. repoID .. '/resources/' .. resourceId
 	return getElementBySearchQuery(searchResourceReq)
 end
-
-
-function getResourceIdByCallNumber(callNumb, repoId)
-	results = getResourceByCallNumber(callNumb, repoId)
-	resource_id = ExtractProperty(results, 'id')
-	pathSplit = split(resource_id, '/')
-	actual_id = pathSplit[#pathSplit]
-	return actual_id
-end
-
 
 function getResourceByCallNumber(callNumb, repoId)
 	local searchResourceReq = 'repositories/' .. repoId .. '/search?page=1&q=four_part_id:("' .. callNumb .. '")&type[]=resource'
@@ -208,7 +194,6 @@ function getTopContainersByCallNumber(callNumb)
 	return getTopContainersBySearchQuery('q=collection_identifier_u_stext:("'..callNumb..'")')
 end
 
-
 function getTopContainersByTitle(title)
 	return getTopContainersBySearchQuery('q=collection_display_string_u_sstr:("'..title..'")')
 end
@@ -216,8 +201,6 @@ end
 function getTopContainersByBarcode(barcode)
 	return getTopContainersBySearchQuery('q=barcode_u_sstr:("'..barcode..'")')
 end
-
-
 
 function getTopContainersByEADID(eadid)
 	-- ead_id is always lowercase in the db. ':lower()' makes the search case insensitive on the user side.
@@ -310,46 +293,6 @@ function getElementBySearchQuery(searchQuery)
 	end
 	return res
 end
-
-function checkRepoCode(repoCode)
-	local transRepoCode = GetFieldValue("Transaction", "Location") 
-	if transRepoCode == nil or transRepoCode == '' then
-		return -- in a hypothetical request with no repo code. 
-	end
-	if transRepoCode ~= repoCode then
-		interfaceMngr:ShowMessage('You are not authorized to make top containers search on this repository', 'Warning')
-		return 
-	end
-end
-
-function getRepoCode(repoID)
-	local searchResourceReq = 'repositories/' .. repoID
-	local res = getElementBySearchQuery(searchResourceReq)
-	return ExtractProperty(res, "repo_code")
-end
-
-
-function getRepoId(repoCode)
-	local searchResourceReq = 'repositories'
-	local res = getElementBySearchQuery(searchResourceReq)
-	for i=1, #res do
-		local currRepo = res[i]
-		if ExtractProperty(currRepo, 'repo_code') == repoCode then
-			local repoUri = split(ExtractProperty(currRepo, 'uri'), '/')
-			return repoUri[#repoUri] 
-		end
-	end
-	return nil
-end
-
-
--- cannot use '#' if the table is not numerically indexed in sequence. 
-function tableLength(T)
-  local count = 0
-  for _ in pairs(T) do count = count + 1 end
-  return count
-end
-
 
 function getListOfRepo()
 	local resTable = {}
@@ -467,7 +410,6 @@ function jsonArrayToDataTable(json_arr, repoCode)
 	return asItemTable
 end
 
-
 function extractTopContainersInformation(obj, callNumber, title, repoCode)
 	local row = {}
 	row['callNumber'] = truncateIfNotNil(callNumber)
@@ -574,7 +516,6 @@ function GetBoxes(tab, itemQuery)
 			LogDebug("No results returned from webservice on box search") 
 		end
 end
-
 
 function importContainer() DoItemImport(false) end
 
@@ -690,7 +631,6 @@ function DoItemImport(withCitation) --note no ID since even for the event handle
 	LogDebug("Switching to the detail tab.")
 	ExecuteCommand("SwitchTab", {"Detail"})
 end
-
 
 function getAccessionCreatorAgentById(accessId, repoId)
 	local searchQuery = '/repositories/'..repoId..'/accessions/'..accessId

--- a/Main.lua
+++ b/Main.lua
@@ -104,7 +104,7 @@ function Init()
 	form:LoadLayout("layout.xml") 
 
 	form:Show() 
-	local result = nil 
+	local result = {} 
 	local searchTypeStr = 'call number'
 
 	if callNumber == nil or callNumber == ''  then
@@ -117,6 +117,7 @@ function Init()
 	else
 		result = getTopContainersByCallNumber(callNumber)
 	end
+
 	local tab = convertResultsIntoDataTable(result)
 
 	GetBoxes(tab, searchTypeStr)
@@ -201,9 +202,6 @@ function getTopContainersByCallNumber(callNumb)
 	return getTopContainersBySearchQuery('q=collection_identifier_u_stext:("'..callNumb..'")')
 end
 
--- function getTopContainersByCallNumberUnfuzzy(callNumb)
---	return getTopContainersBySearchQuery('q=collection_identifier_stored_u_sstr:("'..callNumb..'")')
--- end
 
 function getTopContainersByTitle(title)
 	return getTopContainersBySearchQuery('q=collection_display_string_u_sstr:("'..title..'")')
@@ -215,7 +213,7 @@ function getTopContainersByEADID(eadid)
 	if callNumber == nil then
 		return nil
 	end
-	return getTopContainersByCallNumberUnfuzzy(callNumber)
+	return getTopContainersByCallNumber(callNumber)
 end
 
 function getTopContainersBySearchQuery(searchQuery)
@@ -335,6 +333,7 @@ function getListOfRepo()
 			resTable[repoCode] = repoId
 		end
 	end
+	interfaceMngr:ShowMessage('Time spent (in s): '..os.difftime(end_time, start_time), 'Info')
 	return resTable
 end
 

--- a/Main.lua
+++ b/Main.lua
@@ -222,7 +222,6 @@ end
 function getTopContainersByEADID(eadid)
 	-- ead_id is always lowercase in the db. ':lower()' makes the search case insensitive on the user side.
 	local repoCode = string.match(eadid, '[a-zA-Z][a-zA-Z][a-zA-Z]')
-	interfaceMngr:ShowMessage(repoCode, 'eadid filtered')
 	if repoCode == nil or repoCode == '' then
 		-- need to return an empty table as the return argument will get passed to convertResultsIntoDataTable
 		-- which expect to have a table as argument.
@@ -234,7 +233,6 @@ function getTopContainersByEADID(eadid)
 	end
 
 	local repoId = settings["repoTable"][repoCode]
-	interfaceMngr:ShowMessage(repoId, 'repoId')
 	
 	if repoId == nil or repoId == '' then
 		return {}

--- a/layout.xml
+++ b/layout.xml
@@ -17,7 +17,7 @@
     <property name="UseDefaultLookAndFeel">true</property>
     <property name="UseWindowsXPTheme">false</property>
   </property>
-  <property name="Items" iskey="true" value="10">
+  <property name="Items" iskey="true" value="11">
     <property name="Item1" isnull="true" iskey="true">
       <property name="TypeName">LayoutGroup</property>
       <property name="TabbedGroupParentName" />
@@ -69,7 +69,7 @@
         <property name="RowDefinitions" iskey="true" value="0" />
         <property name="ColumnDefinitions" iskey="true" value="0" />
       </property>
-      <property name="Size">@3,Width=977@3,Height=327</property>
+      <property name="Size">@3,Width=977@3,Height=520</property>
       <property name="ExpandButtonVisible">false</property>
       <property name="ExpandButtonMode">Normal</property>
       <property name="HeaderButtonsLocation">Default</property>
@@ -490,8 +490,8 @@
       <property name="TextToControlDistance">0</property>
       <property name="Spacing">0, 0, 0, 0</property>
       <property name="Padding">2, 2, 2, 2</property>
-      <property name="Location">@1,X=0@2,Y=72</property>
-      <property name="Size">@3,Width=977@3,Height=231</property>
+      <property name="Location">@1,X=0@2,Y=96</property>
+      <property name="Size">@3,Width=977@3,Height=400</property>
       <property name="ShowInCustomizationForm">true</property>
       <property name="Text">ArchivesSpace Results</property>
       <property name="CustomizationFormText">MySqlGrid</property>
@@ -569,7 +569,7 @@
       <property name="TextToControlDistance">3</property>
       <property name="Spacing">0, 0, 0, 0</property>
       <property name="Padding">2, 2, 2, 2</property>
-      <property name="Location">@1,X=0@3,Y=303</property>
+      <property name="Location">@1,X=0@3,Y=496</property>
       <property name="Size">@3,Width=977@2,Height=24</property>
       <property name="ShowInCustomizationForm">true</property>
       <property name="Text">Number of item founds:</property>
@@ -579,6 +579,85 @@
       <property name="TextLocation">Default</property>
     </property>
     <property name="Item7" isnull="true" iskey="true">
+      <property name="TypeName">AtlasSystems.Scripting.UI.AddonControls.TextEdit</property>
+      <property name="ControlName">barcode</property>
+      <property name="AllowHtmlStringInCaption">false</property>
+      <property name="TextAlignMode">UseParentOptions</property>
+      <property name="SizeConstraintsType">Default</property>
+      <property name="Image" isnull="true" />
+      <property name="ImageIndex">-1</property>
+      <property name="ImageAlignment">MiddleLeft</property>
+      <property name="ImageToTextDistance">5</property>
+      <property name="OptionsPrint" isnull="true" iskey="true">
+        <property name="TextToControlDistance">-1</property>
+        <property name="AllowPrint">true</property>
+        <property name="AppearanceItemCaption" isnull="true" iskey="true">
+          <property name="ForeColor" />
+          <property name="BorderColor" />
+          <property name="BackColor" />
+          <property name="BackColor2" />
+          <property name="Font">Tahoma, 8.25pt</property>
+          <property name="GradientMode">Horizontal</property>
+          <property name="FontSizeDelta">0</property>
+          <property name="FontStyleDelta">Regular</property>
+        </property>
+      </property>
+      <property name="MaxSize">@1,Width=0@2,Height=24</property>
+      <property name="MinSize">@3,Width=170@2,Height=24</property>
+      <property name="ControlAlignment">TopLeft</property>
+      <property name="ContentVisible">true</property>
+      <property name="TrimClientAreaToControl">true</property>
+      <property name="AllowGlyphSkinning">Default</property>
+      <property name="OptionsCustomization" isnull="true" iskey="true">
+        <property name="AllowDrag">Default</property>
+        <property name="AllowDrop">Default</property>
+      </property>
+      <property name="OptionsTableLayoutItem" isnull="true" iskey="true">
+        <property name="RowIndex">0</property>
+        <property name="RowSpan">1</property>
+        <property name="ColumnIndex">0</property>
+        <property name="ColumnSpan">1</property>
+      </property>
+      <property name="OptionsToolTip" isnull="true" iskey="true">
+        <property name="ToolTip" />
+        <property name="ToolTipTitle" />
+        <property name="ToolTipIconType">None</property>
+        <property name="ImmediateToolTip">false</property>
+        <property name="AllowHtmlString">Default</property>
+        <property name="IconToolTip" />
+        <property name="IconToolTipTitle" />
+        <property name="IconToolTipIconType">None</property>
+        <property name="EnableIconToolTip">true</property>
+        <property name="IconImmediateToolTip">false</property>
+        <property name="IconAllowHtmlString">Default</property>
+      </property>
+      <property name="Name">barcode</property>
+      <property name="AppearanceItemCaption" isnull="true" iskey="true">
+        <property name="ForeColor" />
+        <property name="BorderColor" />
+        <property name="BackColor" />
+        <property name="BackColor2" />
+        <property name="Font">Tahoma, 8.25pt</property>
+        <property name="GradientMode">Horizontal</property>
+        <property name="FontSizeDelta">0</property>
+        <property name="FontStyleDelta">Regular</property>
+      </property>
+      <property name="ParentName">Root</property>
+      <property name="TextVisible">true</property>
+      <property name="TextSize">@3,Width=113@2,Height=13</property>
+      <property name="TextToControlDistance">3</property>
+      <property name="Spacing">0, 0, 0, 0</property>
+      <property name="Padding">2, 2, 2, 2</property>
+      <property name="Location">@1,X=0@2,Y=72</property>
+      <property name="Size">@3,Width=977@2,Height=24</property>
+      <property name="ShowInCustomizationForm">true</property>
+      <property name="Text">Barcode</property>
+      <property name="CustomizationFormText">barcode</property>
+      <property name="StartNewLine">false</property>
+      <property name="Visibility">Always</property>
+      <property name="TextLocation">Default</property>
+    </property>
+    <property name="Item8" isnull="true" iskey="true">
       <property name="TypeName">TabbedGroup</property>
       <property name="MultiLine">Default</property>
       <property name="HeaderAutoFill">Default</property>
@@ -684,7 +763,7 @@
       <property name="StartNewLine">false</property>
       <property name="Visibility">Always</property>
     </property>
-    <property name="Item8" isnull="true" iskey="true">
+    <property name="Item9" isnull="true" iskey="true">
       <property name="TypeName">LayoutGroup</property>
       <property name="TabbedGroupParentName" />
       <property name="GroupBordersVisible">true</property>
@@ -849,7 +928,7 @@
       <property name="StartNewLine">false</property>
       <property name="Visibility">Always</property>
     </property>
-    <property name="Item9" isnull="true" iskey="true">
+    <property name="Item10" isnull="true" iskey="true">
       <property name="TypeName">LayoutGroup</property>
       <property name="TabbedGroupParentName" />
       <property name="GroupBordersVisible">true</property>
@@ -1014,7 +1093,7 @@
       <property name="StartNewLine">false</property>
       <property name="Visibility">Always</property>
     </property>
-    <property name="Item10" isnull="true" iskey="true">
+    <property name="Item11" isnull="true" iskey="true">
       <property name="TypeName">TabbedGroup</property>
       <property name="MultiLine">Default</property>
       <property name="HeaderAutoFill">Default</property>


### PR DESCRIPTION
New features: 
* The ability to search for a top container by a barcode. Will display as many entries in the grid as there is resources/accessions associated with this top container. (this is the only search type which i not directly tied to a resource/accession, hence this behavior).
* Top containers associated to an Accession imports correctly. Those kind of top containers could already be searched before, but the import would not be complete.
* EADID search would return results coming from other collections as a side effect of the unfuzzy call number search. Before the EADID search was implemented by getting the call number using the EADID and then doing a normal call number search. This was fixed by searching through the id of a resource rather than the call number, and the id search is strict.